### PR TITLE
change coding: utf8 to utf-8

### DIFF
--- a/cssselect/__init__.py
+++ b/cssselect/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     CSS Selectors based on XPath
     ============================

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cssselect.parser
     ================

--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding: utf8
+# coding: utf-8
 """
     Tests for cssselect
     ===================

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cssselect.xpath
     ===============

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import re
 import os.path


### PR DESCRIPTION
On my python34 (windows 8), I get the following error loading cssselect

  File "setup.py", line 1
SyntaxError: encoding problem: utf8

This doesn't happen on python27. I'm not sure if this is a python 3.4 thing necessarily, but changing the encodings to 'utf-8' fixes the issue for both. utf-8 (with hyphen) is also what's used in most sample coding specifications e.g. in the PEP https://www.python.org/dev/peps/pep-0263/