### PR TITLE
Using non-ascii characters in xpath

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -233,7 +233,10 @@ class GenericTranslator(object):
 
     @staticmethod
     def xpath_literal(s):
-        s = _unicode(s)
+        try:
+            s = _unicode(s)
+        except UnicodeDecodeError:
+            s = s.decode('utf-8', 'ignore')
         if "'" not in s:
             s = "'%s'" % s
         elif '"' not in s:


### PR DESCRIPTION
Hello. I was trying to use pseudo-class :contains(string) on some page, in pyquery library. I was trying to find some Cyrillic(Russian) text on the page, something like node.find(":contains('персональный')") and got an "UnicodeDecodeError" exception. 

It's happening because :contains string argument being converted to xpath expression using xpath_literal function(if i understood all right), and non-ascii characters can't be converted to unicode. 

The solution is to catch "UnicodeDecodeError" and then try to decode character by proper encoding, "utf-8" for example.